### PR TITLE
tfdbg LocalCLIDebugWrapperSession works in CoLab

### DIFF
--- a/courses/machine_learning/deepdive/03_tensorflow/debug_demo.ipynb
+++ b/courses/machine_learning/deepdive/03_tensorflow/debug_demo.ipynb
@@ -348,7 +348,7 @@
     "      [2, 8, 7]\n",
     "    ])\n",
     "    \n",
-    "  sess = tf_debug.LocalCLIDebugWrapperSession(sess)\n",
+    "  sess = tf_debug.LocalCLIDebugWrapperSession(sess, ui_type=\"readline\")\n",
     "  sess.add_tensor_filter(\"has_inf_or_nan\", tf_debug.has_inf_or_nan)\n",
     "  print sess.run(some_method(fake_a, fake_b))"
    ]
@@ -364,9 +364,9 @@
    "outputs": [],
    "source": [
     "%bash\n",
-    "# Note: doesn't work because Datalab is not an interactive terminal\n",
-    "# You have to ssh into Docker image and run it in a terminal or have TensorFlow locally installed.\n",
-    "# Sorry :(\n",
+    "# Note: won't work without the ui_type=\"readline\" argument because Datalab is not an interactive terminal\n",
+    "# and doesn't support the default \"curses\" ui_type. If you would like to use the default \"curses\" UI,\n",
+    "# you have to ssh into Docker image and run it in a terminal or have TensorFlow locally installed.\n",
     "# python debugger.py --debug"
    ]
   },


### PR DESCRIPTION
with a special keyword argumnet: `ui_type="readline"`